### PR TITLE
Move Swagger UI to root and update health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ Run locally:
 
 Endpoints:
 
-- `GET /` – health check `{ "status": "ok" }`
+- `GET /health` – health check `{ "status": "ok" }`
+- `GET /` – Swagger UI
 - `GET /weather` – hello world for weather

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 
-app = FastAPI(title="Hello Weather API")
+# Serve Swagger UI at the root path
+app = FastAPI(title="Hello Weather API", docs_url="/", redoc_url=None)
 
 
-@app.get("/", summary="Health check")
+@app.get("/health", summary="Health check")
 def read_root():
     return {"status": "ok"}
 
@@ -11,4 +12,3 @@ def read_root():
 @app.get("/weather", summary="Hello world weather endpoint")
 def read_weather():
     return {"message": "Hello, world"}
-


### PR DESCRIPTION
## Summary
- Moved Swagger UI documentation to the root endpoint `/`
- Changed health check endpoint from `/` to `/health`
- Updated README to reflect these endpoint changes

## Changes

### API Endpoints
- Swagger UI is now served at `/` instead of the default `/docs`
- Health check endpoint moved to `/health` returning `{ "status": "ok" }`

### Documentation
- README updated to list `/health` as the health check endpoint
- Added `/` as the Swagger UI endpoint in the README

## Test plan
- [x] Access root `/` and verify Swagger UI loads
- [x] Call `/health` endpoint and verify response `{ "status": "ok" }`
- [x] Confirm `/weather` endpoint still returns expected message
- [x] Validate README instructions match the new endpoints


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/be886852-3c5b-49a0-abd6-ea11a52b76c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API documentation (Swagger UI) is now available at GET / for easy exploration of endpoints.

* **Refactor**
  * Health check endpoint moved from GET / to GET /health. Existing GET /weather endpoint remains unchanged.

* **Documentation**
  * README updated to reflect the new locations of the health check and API docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->